### PR TITLE
Export GPX as single dense track for navigation app compatibility

### DIFF
--- a/app.py
+++ b/app.py
@@ -491,6 +491,11 @@ def result():
             'description': description,
             'waypoints': pruned_route,
             'geometry': pruned_route,  # Use waypoints for map display (cleaner, works with Leaflet)
+            # Full, dense road-following geometry (intermediate OSM nodes expanded back
+            # in by find_route_max_coverage_optimized). Used for GPX export so navigation
+            # apps follow the actual coverage route street-by-street instead of straight
+            # lines between intersections. See export_gpx().
+            'track': optimized_route,
             'instructions': consolidate_turn_by_turn(turn_by_turn_instructions),
             'route_info': route_info
         })
@@ -700,6 +705,22 @@ def export_gpx():
     duration_min = route_info.get('total_duration_min', 0)
     route_name = route_data['name']
     
+    # Emit a single <trk> with the full, dense road-following geometry.
+    #
+    # We deliberately export ONLY a track (no standalone <wpt> pins and no <rte>):
+    # navigation apps such as OsmAnd import a file containing a <trk> as a track
+    # ("trail") and, with "Follow track + Calculate route between points (Car)",
+    # walk its points in order. Because this is a coverage (Chinese-Postman-style)
+    # route that intentionally re-drives streets, the geometry must be DENSE so the
+    # router has no room to shortcut/optimize across blocks and drop a revisit --
+    # hence 'track' (the expanded route) rather than the pruned 'geometry'.
+    # Mixing <wpt>/<rte> into the same file previously made OsmAnd treat it as a
+    # plain track with no progression, so they are omitted on purpose.
+    track = (route_data.get('track')
+             or route_data.get('geometry')
+             or route_data.get('waypoints')
+             or [])
+
     gpx_content = '<?xml version="1.0" encoding="UTF-8"?>\n'
     gpx_content += '<gpx version="1.1" creator="FoodTruckRouteOptimizer" xmlns="http://www.topografix.com/GPX/1/1">\n'
     gpx_content += f'  <metadata>\n'
@@ -707,41 +728,15 @@ def export_gpx():
     gpx_content += f'    <desc>Route: {distance_miles} miles, {duration_min:.0f} min. {route_data["description"]}</desc>\n'
     gpx_content += f'    <time>{datetime.utcnow().isoformat()}Z</time>\n'
     gpx_content += f'  </metadata>\n'
-    
-    # Add waypoints
-    waypoints = route_data.get('waypoints', [])
-    for i, (lat, lon) in enumerate(waypoints):
-        name = 'Start' if i == 0 else ('End' if i == len(waypoints) - 1 else f'Waypoint {i}')
-        gpx_content += f'  <wpt lat="{lat}" lon="{lon}">\n'
-        gpx_content += f'    <name>{name}</name>\n'
-        gpx_content += f'  </wpt>\n'
-    
-    # Add route track (full geometry)
-    geometry = route_data.get('geometry')
-    if geometry:
-        gpx_content += '  <trk>\n'
-        gpx_content += f'    <name>{route_name}</name>\n'
-        gpx_content += '    <trkseg>\n'
-        for lat, lon in geometry:
-            gpx_content += f'      <trkpt lat="{lat}" lon="{lon}"></trkpt>\n'
-        gpx_content += '    </trkseg>\n'
-        gpx_content += '  </trk>\n'
-    
-    # Add route with turn-by-turn instructions as route points
-    instructions = route_data.get('instructions', [])
-    if instructions and waypoints:
-        gpx_content += '  <rte>\n'
-        gpx_content += '    <name>Turn-by-Turn Route</name>\n'
-        for i, (lat, lon) in enumerate(waypoints):
-            gpx_content += f'    <rtept lat="{lat}" lon="{lon}">\n'
-            if i < len(instructions):
-                inst = instructions[i]
-                gpx_content += f'      <name>{inst.get("instruction", "Continue")}</name>\n'
-                if inst.get('name'):
-                    gpx_content += f'      <desc>onto {inst["name"]}</desc>\n'
-            gpx_content += f'    </rtept>\n'
-        gpx_content += '  </rte>\n'
-    
+
+    gpx_content += '  <trk>\n'
+    gpx_content += f'    <name>{route_name}</name>\n'
+    gpx_content += '    <trkseg>\n'
+    for lat, lon in track:
+        gpx_content += f'      <trkpt lat="{lat}" lon="{lon}"></trkpt>\n'
+    gpx_content += '    </trkseg>\n'
+    gpx_content += '  </trk>\n'
+
     gpx_content += '</gpx>'
     
     # Return as downloadable file with route-specific filename

--- a/tests/gen_real_gpx.py
+++ b/tests/gen_real_gpx.py
@@ -117,6 +117,7 @@ route_data = {
     "description": "test",
     "waypoints": pruned_route,
     "geometry": pruned_route,
+    "track": optimized_route,  # dense road-following geometry for GPX export
     "instructions": instructions,
     "route_info": {"total_distance_miles": 1.23, "total_duration_min": 9.0},
 }
@@ -126,6 +127,8 @@ distance_miles = route_data["route_info"]["total_distance_miles"]
 duration_min = route_data["route_info"]["total_duration_min"]
 route_name = route_data["name"]
 
+track = route_data.get("track") or route_data.get("geometry") or route_data.get("waypoints") or []
+
 gpx = '<?xml version="1.0" encoding="UTF-8"?>\n'
 gpx += '<gpx version="1.1" creator="FoodTruckRouteOptimizer" xmlns="http://www.topografix.com/GPX/1/1">\n'
 gpx += '  <metadata>\n'
@@ -134,31 +137,12 @@ gpx += f'    <desc>Route: {distance_miles} miles, {duration_min:.0f} min. {route
 gpx += f'    <time>{datetime.utcnow().isoformat()}Z</time>\n'
 gpx += '  </metadata>\n'
 
-waypoints = route_data.get("waypoints", [])
-for i, (lat, lon) in enumerate(waypoints):
-    name = 'Start' if i == 0 else ('End' if i == len(waypoints) - 1 else f'Waypoint {i}')
-    gpx += f'  <wpt lat="{lat}" lon="{lon}">\n    <name>{name}</name>\n  </wpt>\n'
-
-geometry = route_data.get("geometry")
-if geometry:
-    gpx += '  <trk>\n'
-    gpx += f'    <name>{route_name}</name>\n'
-    gpx += '    <trkseg>\n'
-    for lat, lon in geometry:
-        gpx += f'      <trkpt lat="{lat}" lon="{lon}"></trkpt>\n'
-    gpx += '    </trkseg>\n  </trk>\n'
-
-if instructions and waypoints:
-    gpx += '  <rte>\n    <name>Turn-by-Turn Route</name>\n'
-    for i, (lat, lon) in enumerate(waypoints):
-        gpx += f'    <rtept lat="{lat}" lon="{lon}">\n'
-        if i < len(instructions):
-            inst = instructions[i]
-            gpx += f'      <name>{inst.get("instruction", "Continue")}</name>\n'
-            if inst.get("name"):
-                gpx += f'      <desc>onto {inst["name"]}</desc>\n'
-        gpx += '    </rtept>\n'
-    gpx += '  </rte>\n'
+gpx += '  <trk>\n'
+gpx += f'    <name>{route_name}</name>\n'
+gpx += '    <trkseg>\n'
+for lat, lon in track:
+    gpx += f'      <trkpt lat="{lat}" lon="{lon}"></trkpt>\n'
+gpx += '    </trkseg>\n  </trk>\n'
 
 gpx += '</gpx>'
 
@@ -166,4 +150,4 @@ out = os.path.join(os.path.dirname(__file__), "sample_route.gpx")
 with open(out, "w") as f:
     f.write(gpx)
 print(f"\nwrote {out}")
-print(f"counts -> wpt:{len(waypoints)}  trkpt:{len(geometry)}  rtept:{len(waypoints)}  rte_names:{len(instructions)}")
+print(f"counts -> dense trkpt:{len(track)}  (vs pruned waypoints:{len(pruned_route)})")

--- a/tests/gen_real_gpx.py
+++ b/tests/gen_real_gpx.py
@@ -1,0 +1,169 @@
+"""
+Drive the REAL routing pipeline on a small, realistic neighborhood and emit a
+GPX file using the exact logic from app.export_gpx, so the output can be
+inspected the way OsmAnd would consume it.
+
+Run:  python tests/gen_real_gpx.py
+"""
+import os
+import sys
+from datetime import datetime
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from find_route import (
+    simplify_graph,
+    find_route_max_coverage_optimized,
+    prune_common_sense_nodes,
+)
+from app import consolidate_turn_by_turn
+
+
+# --- Build a small neighborhood: a 4x3 grid + one curved street -------------
+# Coordinates near Palo Alto, spacing ~ a city block (~0.0009 deg ~ 100m).
+LAT0, LON0 = 37.4400, -122.1500
+DLAT = 0.0009
+DLON = 0.0011
+
+nodes = {}
+ROWS, COLS = 3, 4
+def nid(r, c):
+    return r * 100 + c
+
+for r in range(ROWS):
+    for c in range(COLS):
+        nodes[nid(r, c)] = (LAT0 + r * DLAT, LON0 + c * DLON)
+
+# Add a couple of mid-block geometry nodes to give one street real curvature.
+nodes[9001] = (LAT0 + 0.5 * DLAT + 0.0003, LON0 + 1.5 * DLON)  # bulge on a curve
+
+ways = []
+# Horizontal streets (named like real residential roads).
+hnames = ["Maple Street", "Oak Avenue", "Elm Street"]
+for r in range(ROWS):
+    ways.append({
+        "name": hnames[r],
+        "highway": "residential",
+        "nodes": [nid(r, c) for c in range(COLS)],
+    })
+# Vertical streets.
+vnames = ["First Street", "Second Street", "Third Street", "Fourth Street"]
+for c in range(COLS):
+    ways.append({
+        "name": vnames[c],
+        "highway": "residential",
+        "nodes": [nid(r, c) for r in range(ROWS)],
+    })
+# One curved connector that passes through a mid-block geometry node.
+ways.append({
+    "name": "Willow Bend",
+    "highway": "residential",
+    "nodes": [nid(0, 1), 9001, nid(1, 2)],
+})
+
+settings = {
+    "coverage_mode": "balanced",
+    "min_street_length": 0,
+    "speed_priority": "balanced",
+    "node_snap_distance_m": 18,
+    "filter_dead_ends": False,
+}
+
+start_node = nid(0, 0)
+end_node = nid(2, 3)
+
+graph = simplify_graph(nodes, ways, settings=settings,
+                       start_node=start_node, end_node=end_node)
+print(f"graph: {graph.number_of_nodes()} nodes, {graph.number_of_edges()} edges")
+
+result = find_route_max_coverage_optimized(graph, start_node, end_node, settings=settings)
+optimized_route = result["route"]
+print(f"optimized_route (expanded): {len(optimized_route)} coords")
+
+way_ids = [None] * len(optimized_route)
+pruned_route = prune_common_sense_nodes(optimized_route, way_ids=way_ids,
+                                        angle_threshold=30, graph=graph)
+print(f"pruned_route (waypoints):   {len(pruned_route)} coords")
+
+# Build turn-by-turn exactly like app.py /result does.
+turn_by_turn_instructions = []
+for i in range(len(optimized_route) - 1):
+    curr_coord = optimized_route[i]
+    next_coord = optimized_route[i + 1]
+    curr_node = next_node = None
+    for node, data in graph.nodes(data=True):
+        if data.get("coordinates") == curr_coord:
+            curr_node = node
+        if data.get("coordinates") == next_coord:
+            next_node = node
+    if curr_node and next_node and graph.has_edge(curr_node, next_node):
+        edge_data = graph[curr_node][next_node]
+        distance = edge_data.get("distance", 0)
+        street_name = edge_data.get("way_id", "unnamed road")
+        turn_by_turn_instructions.append({
+            "instruction": f"Continue on {street_name}",
+            "name": street_name,
+            "distance": distance,
+            "duration": distance / 8.33,
+        })
+
+instructions = consolidate_turn_by_turn(turn_by_turn_instructions)
+print(f"raw instruction segments:   {len(turn_by_turn_instructions)}")
+print(f"consolidated instructions:  {len(instructions)}")
+
+route_data = {
+    "priority": "balanced",
+    "name": "Balanced Route",
+    "description": "test",
+    "waypoints": pruned_route,
+    "geometry": pruned_route,
+    "instructions": instructions,
+    "route_info": {"total_distance_miles": 1.23, "total_duration_min": 9.0},
+}
+
+# --- Emit GPX with the EXACT logic from app.export_gpx ----------------------
+distance_miles = route_data["route_info"]["total_distance_miles"]
+duration_min = route_data["route_info"]["total_duration_min"]
+route_name = route_data["name"]
+
+gpx = '<?xml version="1.0" encoding="UTF-8"?>\n'
+gpx += '<gpx version="1.1" creator="FoodTruckRouteOptimizer" xmlns="http://www.topografix.com/GPX/1/1">\n'
+gpx += '  <metadata>\n'
+gpx += f'    <name>{route_name}</name>\n'
+gpx += f'    <desc>Route: {distance_miles} miles, {duration_min:.0f} min. {route_data["description"]}</desc>\n'
+gpx += f'    <time>{datetime.utcnow().isoformat()}Z</time>\n'
+gpx += '  </metadata>\n'
+
+waypoints = route_data.get("waypoints", [])
+for i, (lat, lon) in enumerate(waypoints):
+    name = 'Start' if i == 0 else ('End' if i == len(waypoints) - 1 else f'Waypoint {i}')
+    gpx += f'  <wpt lat="{lat}" lon="{lon}">\n    <name>{name}</name>\n  </wpt>\n'
+
+geometry = route_data.get("geometry")
+if geometry:
+    gpx += '  <trk>\n'
+    gpx += f'    <name>{route_name}</name>\n'
+    gpx += '    <trkseg>\n'
+    for lat, lon in geometry:
+        gpx += f'      <trkpt lat="{lat}" lon="{lon}"></trkpt>\n'
+    gpx += '    </trkseg>\n  </trk>\n'
+
+if instructions and waypoints:
+    gpx += '  <rte>\n    <name>Turn-by-Turn Route</name>\n'
+    for i, (lat, lon) in enumerate(waypoints):
+        gpx += f'    <rtept lat="{lat}" lon="{lon}">\n'
+        if i < len(instructions):
+            inst = instructions[i]
+            gpx += f'      <name>{inst.get("instruction", "Continue")}</name>\n'
+            if inst.get("name"):
+                gpx += f'      <desc>onto {inst["name"]}</desc>\n'
+        gpx += '    </rtept>\n'
+    gpx += '  </rte>\n'
+
+gpx += '</gpx>'
+
+out = os.path.join(os.path.dirname(__file__), "sample_route.gpx")
+with open(out, "w") as f:
+    f.write(gpx)
+print(f"\nwrote {out}")
+print(f"counts -> wpt:{len(waypoints)}  trkpt:{len(geometry)}  rtept:{len(waypoints)}  rte_names:{len(instructions)}")

--- a/tests/test_app.py
+++ b/tests/test_app.py
@@ -97,3 +97,66 @@ def test_result_with_street_data(client, mocker):
     response = client.get(f'/result?boundary_id={boundary_id}&start_node=1&end_node=2')
     assert response.status_code == 200
     assert b"result.html" in response.data or b"route_variants" in response.data or len(response.data) > 0
+
+def test_export_gpx_emits_single_dense_track(client):
+    """GPX export should be a single <trk> built from the dense 'track'
+    geometry, with no <wpt> pins and no <rte> block (so OsmAnd treats it as a
+    follow-able track and does not get a misaligned/ambiguous route)."""
+    import uuid
+    boundary_id = str(uuid.uuid4())
+
+    # Dense road-following geometry (what find_route returns expanded) vs the
+    # sparse pruned waypoints used for on-screen display.
+    dense_track = [
+        (41.8781, -87.6298), (41.8786, -87.6295), (41.8790, -87.6291),
+        (41.8795, -87.6288), (41.8790, -87.6291), (41.8786, -87.6295),
+    ]
+    pruned = [(41.8781, -87.6298), (41.8795, -87.6288)]
+
+    route_variants = [{
+        'priority': 'balanced',
+        'name': 'Balanced Route',
+        'description': 'test',
+        'waypoints': pruned,
+        'geometry': pruned,
+        'track': dense_track,
+        'instructions': [{'instruction': 'Start on A', 'name': 'A'}],
+        'route_info': {'total_distance_miles': 1.2, 'total_duration_min': 9},
+    }]
+
+    os.makedirs("temp", exist_ok=True)
+    with open(os.path.join("temp", f"{boundary_id}_routes.pkl"), "wb") as f:
+        pickle.dump(route_variants, f)
+
+    resp = client.get(f'/export_gpx?boundary_id={boundary_id}&route_option=balanced')
+    assert resp.status_code == 200
+    body = resp.data.decode()
+
+    # Well-formed XML.
+    import xml.dom.minidom as minidom
+    minidom.parseString(body)
+
+    # Single track, dense, with no competing wpt/rte structures.
+    assert '<trk>' in body
+    assert '<wpt' not in body
+    assert '<rte>' not in body
+    assert body.count('<trkpt') == len(dense_track)
+
+
+def test_export_gpx_falls_back_when_no_track(client):
+    """Older saved routes without a 'track' key still export using geometry."""
+    import uuid
+    boundary_id = str(uuid.uuid4())
+    geometry = [(41.8781, -87.6298), (41.8795, -87.6288)]
+    route_variants = [{
+        'priority': 'balanced', 'name': 'R', 'description': 't',
+        'waypoints': geometry, 'geometry': geometry, 'instructions': [],
+        'route_info': {'total_distance_miles': 1, 'total_duration_min': 5},
+    }]
+    os.makedirs("temp", exist_ok=True)
+    with open(os.path.join("temp", f"{boundary_id}_routes.pkl"), "wb") as f:
+        pickle.dump(route_variants, f)
+
+    resp = client.get(f'/export_gpx?boundary_id={boundary_id}&route_option=balanced')
+    assert resp.status_code == 200
+    assert resp.data.decode().count('<trkpt') == len(geometry)


### PR DESCRIPTION
## Summary

Refactor GPX export to emit a single `<trk>` element built from the dense, road-following geometry instead of separate `<wpt>` pins and `<rte>` blocks. This ensures navigation apps like OsmAnd treat the coverage route as a followable track and do not shortcut across blocks, which would drop revisits in the Chinese-Postman-style route.

## Changes

- **app.py**:
  - Add `'track': optimized_route` to the route result dict (the expanded, dense geometry from `find_route_max_coverage_optimized`) alongside the pruned `'geometry'` used for on-screen display.
  - Simplify `export_gpx()` to emit only a single `<trk>` with dense geometry, removing the `<wpt>` pins and `<rte>` block that previously caused OsmAnd to treat the route ambiguously.
  - Add detailed comments explaining why a single track is necessary for coverage routes.

- **tests/test_app.py**:
  - Add `test_export_gpx_emits_single_dense_track()` to verify the GPX output contains exactly one `<trk>` with the full dense geometry and no `<wpt>` or `<rte>` elements.
  - Add `test_export_gpx_falls_back_when_no_track()` to ensure backward compatibility with older saved routes that lack a `'track'` key (falls back to `'geometry'`).

- **tests/gen_real_gpx.py** (new file):
  - Standalone test script that builds a small, realistic 4×3 grid neighborhood with one curved street.
  - Runs the full routing pipeline and emits a GPX file using the exact logic from `app.export_gpx()`.
  - Useful for manual inspection of GPX output in OsmAnd or other navigation apps.
  - Demonstrates the difference between dense track points and pruned waypoints.

## Implementation Details

- The `'track'` field stores the full expanded route (all intermediate OSM geometry nodes re-expanded by `find_route_max_coverage_optimized`), while `'geometry'` remains the pruned waypoints for cleaner on-screen display.
- GPX export now uses a fallback chain: `track` → `geometry` → `waypoints` → empty list, ensuring compatibility with both new routes and older pickled routes.
- No `<wpt>` or `<rte>` elements are emitted to avoid OsmAnd's ambiguous route interpretation; the single `<trk>` is sufficient for navigation.

https://claude.ai/code/session_01XK2ADAfLSNwaTAP621qAer