### PR TITLE
Fix reversed edge geometry in route expansion + run pytest in CI

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,29 @@
+name: Tests
+
+on:
+  push:
+    branches: ["**"]
+  pull_request:
+
+jobs:
+  pytest:
+    name: pytest
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+          cache: pip
+          cache-dependency-path: requirements.txt
+
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install -r requirements.txt
+
+      - name: Run test suite
+        run: pytest

--- a/find_route.py
+++ b/find_route.py
@@ -225,25 +225,41 @@ def expand_route_with_geometry(route_path, graph):
         return [(graph.nodes[n]['coordinates'][0], graph.nodes[n]['coordinates'][1]) for n in route_path]
     
     expanded_coords = []
-    expanded_coords.append(tuple(graph.nodes[route_path[0]]['coordinates']))
-    
+
+    def _append(coord):
+        # Drop consecutive duplicate points: they add no geometry and confuse
+        # navigation apps (each duplicate becomes a degenerate via-point).
+        coord = tuple(coord)
+        if not expanded_coords or expanded_coords[-1] != coord:
+            expanded_coords.append(coord)
+
+    _append(graph.nodes[route_path[0]]['coordinates'])
+
     for i in range(1, len(route_path)):
         curr_node = route_path[i - 1]
         next_node = route_path[i]
-        
+
         # Get intermediate node coordinates for this edge
         if graph.has_edge(curr_node, next_node):
             edge_data = graph[curr_node][next_node]
             intermediate_coords = edge_data.get('intermediate_nodes', [])
-            
-            # Add all intermediate node coordinates
+
+            # intermediate_nodes are stored in the orientation they were built
+            # (from 'geom_from'). The graph is undirected, so when the route
+            # traverses this edge in the opposite direction we must reverse them,
+            # otherwise the geometry jumps to the far endpoint and walks the arc
+            # backwards -- a zig-zag that navigation apps turn into a U-turn.
+            geom_from = edge_data.get('geom_from')
+            if geom_from is not None and geom_from != curr_node:
+                intermediate_coords = list(reversed(intermediate_coords))
+
             for coord in intermediate_coords:
                 if coord:  # Skip None/empty entries
-                    expanded_coords.append(tuple(coord))
-        
+                    _append(coord)
+
         # Add the next endpoint
-        expanded_coords.append(tuple(graph.nodes[next_node]['coordinates']))
-    
+        _append(graph.nodes[next_node]['coordinates'])
+
     logger.debug(f"[EXPAND_ROUTE] Expanded route from {len(route_path)} to {len(expanded_coords)} points")
     return expanded_coords
 
@@ -484,7 +500,10 @@ def simplify_graph(nodes, ways, settings=None, start_node=None, end_node=None):
                         weight=total_distance,
                         way_id=way_id,
                         way_length=total_way_length,  # Store full way length for debugging
-                        intermediate_nodes=intermediate_coords  # Store coordinates, not node IDs
+                        intermediate_nodes=intermediate_coords,  # Store coordinates, not node IDs
+                        geom_from=start_node  # Endpoint the intermediate_nodes are ordered FROM;
+                                              # lets expand_route_with_geometry orient them by
+                                              # travel direction (the graph itself is undirected).
                     )
                     edges_added += 1
                     break

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,12 @@
+[pytest]
+testpaths = tests
+# Only collect real unit tests (test_*.py). This intentionally excludes the
+# diagnostic scripts that are run by hand and require a real graph or network:
+#   - tests/quick_coverage_test.py   (matches *_test.py, excluded by this pattern)
+#   - tests/run_coverage_tests.py    (not a test_*.py file)
+#   - tests/gen_real_gpx.py          (pipeline reproducer, run directly)
+#   - tests/analyze_gpx.py           (GPX diagnostic CLI, run directly)
+python_files = test_*.py
+# test_real_graph.py matches test_*.py but is a manual CLI diagnostic, not a
+# unit test (it expects a boundary_id argument / real pickled graph).
+addopts = -q --ignore=tests/test_real_graph.py

--- a/tests/analyze_gpx.py
+++ b/tests/analyze_gpx.py
@@ -1,0 +1,68 @@
+"""
+Diagnose a route GPX exported by the app: count geometry artifacts that cause
+navigation apps (OsmAnd etc.) to insert spurious U-turns when recalculating a
+route between the track points.
+
+Usage:
+    python tests/analyze_gpx.py path/to/route.gpx
+
+Reports:
+  - consecutive duplicate points (degenerate via-points)
+  - exact revisited coordinates (intended coverage re-drives + artifacts)
+  - out-and-back "spikes" (go far out, return next to where you started)
+  - near-U-turn vertices (sharp >150 deg reversals)
+
+High spike / near-U-turn counts that DON'T correspond to intentional coverage
+re-drives point at geometry bugs (e.g. mis-oriented edge geometry). Some U-turns
+are inherent to a coverage route and unavoidable under "Calculate route between
+points"; use this to separate the two.
+"""
+import math
+import re
+import sys
+from collections import Counter
+
+
+def _meters(a, b):
+    dlat = (a[0] - b[0]) * 111000
+    dlon = (a[1] - b[1]) * 111000 * math.cos(math.radians(a[0]))
+    return math.hypot(dlat, dlon)
+
+
+def _angle(p0, p1, p2):
+    v1 = (p1[0] - p0[0], p1[1] - p0[1])
+    v2 = (p2[0] - p1[0], p2[1] - p1[1])
+    n1 = math.hypot(*v1)
+    n2 = math.hypot(*v2)
+    if n1 == 0 or n2 == 0:
+        return None
+    dot = max(-1.0, min(1.0, (v1[0] * v2[0] + v1[1] * v2[1]) / (n1 * n2)))
+    return math.degrees(math.acos(dot))
+
+
+def analyze(path):
+    text = open(path).read()
+    pts = [(float(la), float(lo))
+           for la, lo in re.findall(r'<trkpt lat="([-\d.]+)" lon="([-\d.]+)"', text)]
+    n = len(pts)
+    dups = sum(1 for i in range(1, n) if pts[i] == pts[i - 1])
+    spikes = sum(1 for i in range(1, n - 1)
+                 if _meters(pts[i - 1], pts[i + 1]) < 15 and _meters(pts[i - 1], pts[i]) > 40)
+    counts = Counter(pts)
+    revisits = sum(v - 1 for v in counts.values() if v > 1)
+    uturns = sum(1 for i in range(1, n - 1)
+                 if (_angle(pts[i - 1], pts[i], pts[i + 1]) or 0) > 150
+                 and _meters(pts[i - 1], pts[i]) > 20)
+    print(f"file: {path}")
+    print(f"  trkpt total ............. {n}  (unique {len(counts)})")
+    print(f"  consecutive duplicates .. {dups}")
+    print(f"  revisited coords (extra)  {revisits}")
+    print(f"  out-and-back spikes ..... {spikes}")
+    print(f"  near-U-turn vertices .... {uturns}")
+
+
+if __name__ == "__main__":
+    if len(sys.argv) != 2:
+        print(__doc__)
+        sys.exit(1)
+    analyze(sys.argv[1])

--- a/tests/test_graph_filters.py
+++ b/tests/test_graph_filters.py
@@ -80,3 +80,44 @@ def test_simplify_graph_merges_very_close_nodes():
 
     assert graph.number_of_nodes() == 2
     assert graph.number_of_edges() == 1
+
+
+def test_expand_route_orients_intermediates_by_travel_direction():
+    """Intermediate edge geometry must follow the direction of travel, not the
+    order it was stored in. Otherwise reverse-direction traversal zig-zags and
+    navigation apps insert spurious U-turns."""
+    import networkx as nx
+    from find_route import expand_route_with_geometry
+
+    G = nx.Graph()
+    G.add_node('A', coordinates=(0.0, 0.000))
+    G.add_node('B', coordinates=(0.0, 0.004))
+    arc = [(0.001, 0.001), (0.002, 0.002), (0.001, 0.003)]
+    G.add_edge('A', 'B', intermediate_nodes=arc, geom_from='A')
+
+    fwd = expand_route_with_geometry(['A', 'B'], G)
+    rev = expand_route_with_geometry(['B', 'A'], G)
+
+    # Reverse traversal is exactly the forward path reversed (no jump-back).
+    assert rev == list(reversed(fwd))
+    # And the arc is monotonic in lon for each direction (no backtrack spike).
+    assert [p[1] for p in fwd] == sorted(p[1] for p in fwd)
+    assert [p[1] for p in rev] == sorted((p[1] for p in rev), reverse=True)
+
+
+def test_expand_route_drops_consecutive_duplicate_points():
+    import networkx as nx
+    from find_route import expand_route_with_geometry
+
+    G = nx.Graph()
+    G.add_node(1, coordinates=(0.0, 0.0))
+    G.add_node(2, coordinates=(0.0, 0.001))
+    G.add_node(3, coordinates=(0.0, 0.002))
+    # Empty intermediates so the shared endpoint (node 2) is the only join.
+    G.add_edge(1, 2, intermediate_nodes=[], geom_from=1)
+    G.add_edge(2, 3, intermediate_nodes=[], geom_from=2)
+
+    out = expand_route_with_geometry([1, 2, 3], G)
+    assert out == [(0.0, 0.0), (0.0, 0.001), (0.0, 0.002)]
+    # No consecutive duplicates anywhere.
+    assert all(out[i] != out[i - 1] for i in range(1, len(out)))


### PR DESCRIPTION
## Summary

Follow-up to #16 (merged). Two changes on this branch:

### 1. Fix reversed edge geometry in route expansion
`expand_route_with_geometry` appended each edge's `intermediate_nodes` in their **stored** order regardless of travel direction. The graph is undirected, so edges driven opposite to how their geometry was stored had the curve inserted backwards — the path jumped to the far endpoint, walked the arc in reverse, then landed on the near endpoint. Navigation apps (OsmAnd's *Calculate route between points*) turn each of those zig-zags into a spurious U-turn.

- `simplify_graph` now records `geom_from` (the endpoint the `intermediate_nodes` are ordered from) on each edge.
- `expand_route_with_geometry` reverses the intermediates when the route enters the edge from the other end, and drops consecutive duplicate points (degenerate via-points at edge joins).

A real exported track for a small neighborhood had **19 consecutive duplicates, 14 out-and-back spikes, and 30 near-U-turn vertices**; this removes those artifact classes. (A coverage route still legitimately re-drives streets, so some U-turns under recalc-ON are inherent and not removed by this.)

### 2. Run the pytest suite in CI
- `.github/workflows/tests.yml`: installs `requirements.txt` and runs `pytest` on every push and PR (previously CI only ran CodeQL).
- `pytest.ini`: deterministic collection — only `test_*.py` unit tests run; the manual/diagnostic scripts (`test_real_graph.py`, `quick_coverage_test.py`, `run_coverage_tests.py`, `gen_real_gpx.py`, `analyze_gpx.py`) are excluded since they need a real graph, network, or CLI args.

## Tests
- New unit tests: direction-correct expansion + de-duplication (`tests/test_graph_filters.py`).
- Added `tests/analyze_gpx.py` — a CLI to quantify these artifacts in any exported GPX.
- Full suite: **13 passed** in a clean virtualenv with only `requirements.txt`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)